### PR TITLE
Add a build stage to the Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,23 @@
-FROM python:3.9.2-alpine
-ARG py_logarex_monitor_version
+FROM python:3.9.2-alpine as base
 
 RUN adduser --disabled-password py-logarex-monitor
 USER py-logarex-monitor
 WORKDIR /home/py-logarex-monitor
 
-COPY "dist/py_logarex_monitor-${py_logarex_monitor_version}-py3-none-any.whl" "py_logarex_monitor-${py_logarex_monitor_version}-py3-none-any.whl"
-RUN pip install --user "py_logarex_monitor-${py_logarex_monitor_version}-py3-none-any.whl"
+FROM base as build
+
+ADD --chown=py-logarex-monitor https://raw.githubusercontent.com/python-poetry/poetry/master/get-poetry.py ./
+RUN python get-poetry.py
+
+RUN mkdir -p src/py_logarex_monitor
+COPY py_logarex_monitor ./src/py_logarex_monitor/
+COPY poetry.lock pyproject.toml default-config.toml ./src/
+RUN cd ./src \
+  && ~/.poetry/bin/poetry build --format wheel
+
+FROM base
+
+COPY --from=build "/home/py-logarex-monitor/src/dist/py_logarex_monitor-*-py3-none-any.whl" ./
+RUN pip install --user $(ls py_*.whl)
 
 ENTRYPOINT ["/home/py-logarex-monitor/.local/bin/py-logarex-monitor"]

--- a/README.md
+++ b/README.md
@@ -35,8 +35,7 @@ To deploy from source use [poetry] to install or build a wheel.
 The included `Dockerfile` contains build instructions for an image based on Alpine Linux. The recommended way to build and deploy it is [podman]:
 
 ```
-$ poetry build --format wheel
-$ podman build --rm -t py-logarex-monitor:latest --build-arg py_logarex_monitor_version=0.1.0 .
+$ podman build --rm -t py-logarex-monitor:latest .
 $ podman run \
   --device /dev/ttyUSB0:/dev/ttyUSB0 \
   --volume $(pwd)/default-config.toml:/home/py-logarex-monitor/config.toml:ro \


### PR DESCRIPTION
## Summary

This adds a build stage to the `Dockerfile` to remove the need for a local `poetry` installation. It also means specify the version via a build argument is not required anymore.